### PR TITLE
Fix: 프리플라이트 요청 검증 제외

### DIFF
--- a/backend/src/main/java/com/easypeach/shroopadmin/modules/auth/service/JwtInterceptor.java
+++ b/backend/src/main/java/com/easypeach/shroopadmin/modules/auth/service/JwtInterceptor.java
@@ -20,6 +20,10 @@ public class JwtInterceptor implements HandlerInterceptor {
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
 		Exception {
 
+		if(request.getMethod().equals("OPTIONS")){
+			return true;
+		}
+
 		Cookie[] cookies = request.getCookies();
 
 		if (cookies == null) {


### PR DESCRIPTION
## 🤷 구현한 기능
- 프리플라이트 요청을 인증에서 제외시켰다.
## 🖊️ 추가 설명
- 데이터 변동 사항이 있는 요청의 경우 프리플라이트 요청을 먼저 날리는데, 거기엔 쿠키가 없어서 인터셉터에서 걸려서 에러가 나타나는 버그가 발생했습니다. 이에 인터셉터에서 토큰을 인증하는 코드에서 OPTION라는 이름의 쿠키는 인증을 안하게 제외시켰습니다.
## 📄 참고 사항
